### PR TITLE
Fixes PLP bug, where an api call is fired for each product with the stamped review widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,18 +29,17 @@ modules: [
 ],
 ```
 
-Next you will have to add the Stamped configuration options to `nuxt.config.js` in the `nacelle` config object. You will need you shopify domain and Stamped public API key.
+Next you will have to add the Stamped configuration options to `nuxt.config.js` in the `env` config object. You will need you shopify domain and Stamped public API key.
 
 You can find your Stamped api key in their dashboard under "Settings > API Keys". Copy the "API Key Public".
 
 Add these setting parameters to `nuxt.config.js` so it should look something like this:
 
 ```
-nacelle: {
-  spaceID: process.env.NACELLE_SPACE_ID,
-  token: process.env.NACELLE_GRAPHQL_TOKEN,
-  gaID: process.env.NACELLE_GA_ID,
-  fbID: process.env.NACELLE_FB_ID,
+env: {
+  nacelleSpaceID: process.env.NACELLE_SPACE_ID,
+  nacelleToken: process.env.NACELLE_GRAPHQL_TOKEN,
+  buildMode: process.env.BUILD_MODE,
   stamped: {
     domain: '<store name here>.myshopify.com',
     apiKey: 'XXXXXXXXXXXX',
@@ -62,4 +61,20 @@ There are two components you can add to your Nacelle site: `<stamped-main-widget
 
 ```
 <stamped-star-rating :product="product">
+```
+
+**Stamped Display Widget** will render a display widget. It also takes the widgetStyle string as a prop.
+
+Options include:
+- [Carousel](https://help.stamped.io/article/44-display-widgets#carousel) => `'carousel'`
+- [Full Page](https://help.stamped.io/article/44-display-widgets#full-page) => `'full-page'`
+- [Visual Gallery](https://help.stamped.io/article/44-display-widgets#gallery) => `'visual-gallery'`
+- [Wall Photos](https://help.stamped.io/article/44-display-widgets#wall-photos) => `'wall-photos'`
+- [Site Badge](https://help.stamped.io/article/44-display-widgets#site-badge) => `'site-badge'`
+- [Side Drawer](https://help.stamped.io/article/44-display-widgets#drawer) => `'drawer'`
+- [Instagram Feed](https://help.stamped.io/article/44-display-widgets#instagram) => `'instagram-feed'`
+- [Net Promoter Score](https://help.stamped.io/article/44-display-widgets#nps) => `'carousel-nps'`
+
+```
+<stamped-star-rating :widgetStyle="full-page">
 ```

--- a/example/nuxt.config.js
+++ b/example/nuxt.config.js
@@ -47,7 +47,11 @@ export default {
   env: {
     nacelleSpaceID: process.env.NACELLE_SPACE_ID,
     nacelleToken: process.env.NACELLE_GRAPHQL_TOKEN,
-    buildMode: process.env.BUILD_MODE
+    buildMode: process.env.BUILD_MODE,
+    stamped: {
+      domain: 'flipfloparch.myshopify.com',
+      apiKey: 'pubkey-gWQ45WvWaY1339MMiZSB3r79iOl078'
+    }
   },
 
   modules: [
@@ -72,11 +76,7 @@ export default {
     spaceID: process.env.NACELLE_SPACE_ID,
     token: process.env.NACELLE_GRAPHQL_TOKEN,
     gaID: process.env.NACELLE_GA_ID,
-    fbID: process.env.NACELLE_FB_ID,
-    stamped: {
-      domain: 'flipfloparch.myshopify.com',
-      apiKey: 'pubkey-gWQ45WvWaY1339MMiZSB3r79iOl078'
-    }
+    fbID: process.env.NACELLE_FB_ID
   },
 
   generate: {

--- a/lib/components/StampedDisplayWidget.vue
+++ b/lib/components/StampedDisplayWidget.vue
@@ -13,34 +13,6 @@ export default {
       type: String,
       default: 'carousel'
     }
-  },
-  mounted () {
-    window.stampedLoaded = window.stampedLoaded || false
-
-    if (!window.stampedLoaded) {
-      // spoof Shopify global var
-      window.Shopify = {}
-      window.Shopify.shop = this.$nacelle.stamped.domain
-
-      // load Stamped script
-      const s = document.createElement('script')
-      s.type = 'text/javascript'
-      s.src = 'https://cdn-stamped-io.azureedge.net/files/widget.min.js'
-      s.setAttribute('data-api-key', this.$nacelle.stamped.apiKey)
-      document.body.appendChild(s)
-
-      window.stampedLoaded = true
-    } else if (window.StampedFn) {
-      setTimeout(() => {
-        window.StampedFn.loadDisplayWidgets()
-      }, 100)
-    } else {
-      const waiting = setInterval(() => {
-        if (window.StampedFn) {
-          clearInterval(waiting)
-        }
-      }, 100)
-    }
   }
 }
 </script>

--- a/lib/components/StampedMainWidget.vue
+++ b/lib/components/StampedMainWidget.vue
@@ -51,34 +51,6 @@ export default {
 
       return ''
     }
-  },
-  mounted () {
-    window.stampedLoaded = window.stampedLoaded || false
-
-    if (!window.stampedLoaded) {
-      // spoof Shopify global var
-      window.Shopify = {}
-      window.Shopify.shop = this.$nacelle.stamped.domain
-
-      // load Stamped script
-      const s = document.createElement('script')
-      s.type = 'text/javascript'
-      s.src = 'https://cdn-stamped-io.azureedge.net/files/widget.min.js'
-      s.setAttribute('data-api-key', this.$nacelle.stamped.apiKey)
-      document.body.appendChild(s)
-
-      window.stampedLoaded = true
-    } else if (window.StampedFn) {
-      setTimeout(() => {
-        window.StampedFn.init()
-      }, 100)
-    } else {
-      const waiting = setInterval(() => {
-        if (window.StampedFn) {
-          clearInterval(waiting)
-        }
-      }, 100)
-    }
   }
 }
 </script>

--- a/lib/components/StampedStarRating.vue
+++ b/lib/components/StampedStarRating.vue
@@ -35,34 +35,6 @@ export default {
 
       return ''
     }
-  },
-  mounted () {
-    window.stampedLoaded = window.stampedLoaded || false
-
-    if (!window.stampedLoaded) {
-      // spoof Shopify global var
-      window.Shopify = {}
-      window.Shopify.shop = this.$nacelle.stamped.domain
-
-      // load Stamped script
-      const s = document.createElement('script')
-      s.type = 'text/javascript'
-      s.src = 'https://cdn-stamped-io.azureedge.net/files/widget.min.js'
-      s.setAttribute('data-api-key', this.$nacelle.stamped.apiKey)
-      document.body.appendChild(s)
-
-      window.stampedLoaded = true
-    } else if (window.StampedFn && !window.stampedBadgesLoaded) {
-      setTimeout(() => {
-        window.StampedFn.loadBadges()
-      }, 200)
-    } else {
-      const waiting = setInterval(() => {
-        if (window.StampedFn) {
-          clearInterval(waiting)
-        }
-      }, 100)
-    }
   }
 }
 </script>

--- a/lib/module.js
+++ b/lib/module.js
@@ -9,11 +9,15 @@ module.exports = function (moduleOptions) {
   }
 
   // Add Stamped Widget script
-  // this.options.head.script.push({
-  //   src: 'https://cdn-stamped-io.azureedge.net/files/widget.min.js',
-  //   async: true,
-  //   'data-api-key': 'pubkey-gWQ45WvWaY1339MMiZSB3r79iOl078'
-  // })
+  this.options.head.script.push({
+    src: 'https://cdn-stamped-io.azureedge.net/files/widget.min.js',
+    defer: true,
+    mode: 'client',
+    body: true,
+    type: 'text/javascript',
+    charset: 'utf-8',
+    'data-api-key': `${this.options.env.stamped.apiKey}`
+  })
 
   // Copy components
   const componentsDir = path.resolve(__dirname, 'components')

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -7,11 +7,51 @@ Vue.component('stamped-main-widget', StampedMainWidget)
 Vue.component('stamped-star-rating', StampedStarRating)
 Vue.component('stamped-display-widget', StampedDisplayWidget)
 
-function addEventListenerStamped(el, eventName, handler) { 
-  if (el.addEventListener) { el.addEventListener(eventName, handler); }
-  else { el.attachEvent('on' + eventName, function () { handler.call(el); }); } 
+function addEventListenerStamped(el, eventName, handler) {
+  if (el.addEventListener) { el.addEventListener(eventName, handler) } else { el.attachEvent('on' + eventName, function () { handler.call(el) }) }
 }
 
 addEventListenerStamped(document, 'stamped:reviews:loaded', function(e) {
-  console.log(e);
-});
+  console.log(e)
+  window.stampedLoaded = true
+})
+
+export default async context => {
+  if (process.browser || process.client) {
+    if (window.StampedGlobalOptions) {
+      window.StampedGlobalOptions.apiKey = context.env.stamped.apiKey
+      window.StampedGlobalOptions.storeUrl = context.env.stamped.domain
+    }
+
+    if (window.StampedFn) {
+      window.StampedFn.init()
+      window.stampedLoaded = true
+    }
+
+    context.app.router.afterEach(async (to, from) => {
+      window.stampedLoaded = false
+      let count = 0
+      let stampedInterval
+
+      if (!window.stampedLoaded) {
+        stampedInterval = setInterval(stampedRouteChangeHandler, 200)
+      }
+
+      function stampedRouteChangeHandler() {
+        if (window.stampedLoaded || count > 5) {
+          clearInterval(stampedInterval)
+        } else {
+          if (window.StampedFn && window.StampedGlobalOptions) {
+            window.StampedGlobalOptions.apiKey = context.env.stamped.apiKey
+            window.StampedGlobalOptions.storeUrl = context.env.stamped.domain
+
+            window.StampedFn.init()
+            window.StampedFn.loadBadges()
+            window.StampedFn.loadDisplayWidgets()
+          }
+          count += 1
+        }
+      }
+    })
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes [[Calls Stamped API more than needed #9](https://github.com/getnacelle/nacelle-stamped-nuxt-module/issues/9)] 


### WHAT is this pull request doing?

This is nearly a rewrite on how we are loading the Stamped script and triggering the widget.

1. First, we are loading the script through the module rather than the component level.

2. To accomplish step 1, we've had to adjust how we are passing in the stamped environment variables. see the changes to `nuxt.congif.js`. This is documented in the `README.md` too.
    - ☝️🚨This is a **BREAKING** change 🚨

3. Instead loading the script and triggering the stamped javascript SDK on each component (which causes a redundancy if there are multiple stamped components on a page.) We are attaching some logic to the router and to load this on a page by page basis. The Stamped SDK searches the DOM tree for appropriate elements and hydrates the widgets as needed.


